### PR TITLE
Fix dtype mismatch when using AMP

### DIFF
--- a/src/trainer.py
+++ b/src/trainer.py
@@ -157,7 +157,12 @@ class Trainer(QThread):
             state_action_values = q_values.gather(1, actions_t.unsqueeze(1))
             
             # Next state Q values using Double DQN
-            next_state_values = torch.zeros(config.BATCH_SIZE, device=self.agent.device)
+            # Ensure dtype matches autocast precision to avoid type mismatch errors
+            next_state_values = torch.zeros(
+                config.BATCH_SIZE,
+                device=self.agent.device,
+                dtype=q_values.dtype,
+            )
             non_final_mask = ~dones_t
             
             if non_final_mask.sum() > 0:


### PR DESCRIPTION
## Summary
- ensure `next_state_values` tensor uses the same dtype as AMP-casted network outputs

## Testing
- `python -m src.main` *(fails: ImportError: cannot import name 'NaN' from numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6870e5f2e6f483298d77ab0682844421